### PR TITLE
Expose group replication port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN set -eux && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y mysql-shell && \
     rm -rf /var/lib/apt/lists/*
 
-EXPOSE 3306 33060
+EXPOSE 3306 33060 33061


### PR DESCRIPTION
# Issue

Group replication port is not exposed by default.


# Solution
Expose group replication port

# Release Notes
* Add port 33061 on Dockerfile
