### PR TITLE
Add xtrabackup Snap to ROCK

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,26 +21,14 @@ platforms: # The platforms this ROCK should be built on and run on
     amd64:
 
 parts:
-    mysql-repo:
-        plugin: nil
-        override-pull: |
-            export DEBIAN_FRONTEND=noninteractive
-            export MYSQL_APT_CONFIG=0.8.23-1
-            apt-get update
-            apt-get install -y wget lsb-release gnupg
-            wget -q https://dev.mysql.com/get/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb \
-                -O /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
-            dpkg -i /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
-            apt-get update
     mysql:
         plugin: nil
-        after: [mysql-repo]
         stage-packages:
-            - mysql-shell
             - mysql-server-8.0
             - util-linux
         stage-snaps:
             - xtrabackup/latest/edge
+            - mysql-shell
     non-root-user:
         plugin: nil
         after: [mysql]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
             - xtrabackup
     non-root-user:
         plugin: nil
-        after: [mysql-deb]
+        after: [mysql]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 1000 mysql

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -24,9 +24,10 @@ parts:
     mysql-repo:
         plugin: nil
         override-pull: |
+            export DEBIAN_FRONTEND=noninteractive
+            export MYSQL_APT_CONFIG=0.8.23-1
             apt-get update
             apt-get install -y wget lsb-release gnupg
-            export MYSQL_APT_CONFIG=0.8.23-1
             wget -q https://dev.mysql.com/get/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb \
                 -O /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
             dpkg -i /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
@@ -39,7 +40,7 @@ parts:
             - mysql-server-8.0
             - util-linux
         stage-snaps:
-            - xtrabackup
+            - xtrabackup/latest/edge
     non-root-user:
         plugin: nil
         after: [mysql]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -31,14 +31,15 @@ parts:
                 -O /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
             dpkg -i /tmp/mysql-apt-config_${MYSQL_APT_CONFIG}_all.deb
             apt-get update
-    mysql-deb:
+    mysql:
         plugin: nil
         after: [mysql-repo]
-        override-stage: |
-            apt install -y \
-              mysql-shell \
-              mysql-server-8.0 \
-              util-linux
+        stage-packages:
+            - mysql-shell
+            - mysql-server-8.0
+            - util-linux
+        stage-snaps:
+            - xtrabackup
     non-root-user:
         plugin: nil
         after: [mysql-deb]


### PR DESCRIPTION
# Issue
<!-- What issue is this PR trying to solve? -->
`xtrabackup` is not included in the ROCK image.

# Solution
<!-- A summary of the solution addressing the above issue -->
Add `xtrabackup` to ROCK by means of `rockcraft` for utilization with the charm.

# Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This should not be merged until this [PR](https://github.com/canonical/charmed-mysql-container/pull/4) is merged.
[craft yaml reference(snapcraft)](https://snapcraft.io/docs/snapcraft-yaml-reference)
[xtrabackup snap](https://snapcraft.io/install/xtrabackup/ubuntu)

# Testing
<!-- What steps need to be taken to test this PR? -->
Built and ran image with xtrabackup included.

# Release Notes
<!-- A digestable summary of the change in this PR -->
xtrabackup snap installed by default
