### PR TITLE
Convert base to snap from deb

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,7 @@
-name: Build
+name: Build ROCK
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   build:
@@ -21,5 +20,5 @@ jobs:
       - name: Upload locally built ROCK artifact
         uses: actions/upload-artifact@v3
         with:
-          name: mysql-server-rock
-          path: "mysql-server_*.rock"
+          name: charmed-mysql-rock
+          path: "charmed-mysql_*.rock"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,7 +35,7 @@ jobs:
           bootstrap-options: "--agent-version 2.9.29"
       - uses: actions/download-artifact@v3
         with:
-          name: mysql-rock
+          name: charmed-mysql-rock
       - name: Install tox
         run: python3 -m pip install tox
       - name: Integration Tests

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,7 +21,6 @@ jobs:
           - integration-self-healing
           - integration-tls
           - integration-backups
-          
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,42 @@
+name: Operator Tests
+
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+  integration:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        env:
+          - integration-charm
+          - integration-database-relation
+          - integration-osm-mysql
+          - integration-replication
+          - integration-self-healing
+          - integration-tls
+          - integration-backups
+          
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          # This is needed until
+          # https://bugs.launchpad.net/juju/+bug/1977582 is fixed
+          bootstrap-options: "--agent-version 2.9.29"
+      - uses: actions/download-artifact@v3
+        with:
+          name: mysql-rock
+      - name: Install tox
+        run: python3 -m pip install tox
+      - name: Integration Tests
+        run: sg microk8s -c "tox -e ${{ matrix.env }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install tox
+        run: python3 -m pip install tox
+      - name: YAML Lint
+        run: tox -e lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
           sudo snap install yq
       - uses: actions/download-artifact@v3
         with:
-          name: mongodb-rock
+          name: charmed-mysql-rock
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -44,6 +44,6 @@ jobs:
           sudo skopeo \
             --insecure-policy \
             copy \
-            oci-archive:"mongodb_${version}_amd64.rock" \
-            docker-daemon:"dataplatformoci/mongodb:${version}"
-          docker push "dataplatformoci/mongodb:${version}"
+            oci-archive:"charmed-mysql_${version}_amd64.rock" \
+            docker-daemon:"dataplatformoci/charmed-mysql:${version}"
+          docker push "dataplatformoci/charmed-mysql:${version}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,14 +1,15 @@
+name: Publish ROCK
 on:
   push:
     branches:
-      - 8.0-20.04
+      - '*.*/stable'
   workflow_dispatch:
     branches:
-      - 8.0-20.04
+      - '*.*/stable'
 
 jobs:
   build:
-      uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build.yaml
   publish:
     needs: build
     runs-on: ubuntu-latest
@@ -29,7 +30,7 @@ jobs:
           sudo snap install yq
       - uses: actions/download-artifact@v3
         with:
-          name: mysql-server-rock
+          name: mongodb-rock
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -43,6 +44,6 @@ jobs:
           sudo skopeo \
             --insecure-policy \
             copy \
-            oci-archive:"mysql-server_${version}_amd64.rock" \
-            docker-daemon:"dataplatformoci/charmed-mysql-server:${version}"
-          docker push "dataplatformoci/charmed-mysql-server:${version}"
+            oci-archive:"mongodb_${version}_amd64.rock" \
+            docker-daemon:"dataplatformoci/mongodb:${version}"
+          docker push "dataplatformoci/mongodb:${version}"

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -9,7 +9,8 @@ on:
 jobs:
   sync:
     name: Sync GitHub issue to Jira
-    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v1
+    uses: "canonical/data-platform-workflows/\
+      .github/workflows/sync_issue_to_jira.yaml@v1"
     with:
       jira-component-name: mysql-k8s
     secrets:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -29,15 +29,18 @@ parts:
             - charmed-mysql/8.0/edge
         override-stage: |
             craftctl default
-            SNAP=$CRAFT_STAGE
-            SNAP_COMMON=$CRAFT_STAGE/etc
-            SNAP_DATA=$CRAFT_STAGE/etc
-            mkdir -p $SNAP_COMMON
-            mkdir -p $SNAP_DATA
+            mkdir -p $CRAFT_STAGE/var/lib/mysql
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 /usr/lib/x86_64-linux-gnu/libnuma.so.1
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 /usr/lib/x86_64-linux-gnu/libaio.so.1
-            mkdir -p $CRAFT_STAGE/var/lib/mysql
-            $CRAFT_STAGE/snap.charmed-mysql/hooks/install
+            rm -rf /var/lib/mysql/
+            mysqld --initialize
+            cp -r /var/lib/mysql $CRAFT_STAGE/var/lib
+            chown 584788:584788 $CRAFT_STAGE/var/lib/mysql
+        override-prime: |
+            craftctl default
+            mv -f $CRAFT_PRIME/etc/mysql/mysql.cnf $CRAFT_PRIME/etc/mysql/my.cnf
+            mkdir -p $CRAFT_PRIME/var/log/mysql
+            chown -R 584788:584788 $CRAFT_PRIME/var/log/mysql
     non-root-user:
         plugin: nil
         after: [charmed-mysql]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -30,9 +30,9 @@ parts:
         override-stage: |
             craftctl default
             mkdir -p $CRAFT_STAGE/var/lib/mysql
-            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 \
+            ln -sf $CRAFT_STAGE/usr/lib/x86_64-linux-gnu/libnuma.so.1 \
                 /usr/lib/x86_64-linux-gnu/libnuma.so.1
-            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 \
+            ln -sf $CRAFT_STAGE/usr/lib/x86_64-linux-gnu/libaio.so.1 \
                 /usr/lib/x86_64-linux-gnu/libaio.so.1
             rm -rf /var/lib/mysql/
             mysqld --initialize

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -30,12 +30,13 @@ parts:
         override-stage: |
             craftctl default
             SNAP=$CRAFT_STAGE
-            SNAP_COMMON=$CRAFT_STAGE/var/snap/charmed-mysql/common
-            SNAP_DATA=$CRAFT_STAGE/var/snap/charmed-mysql/current
+            SNAP_COMMON=$CRAFT_STAGE/etc
+            SNAP_DATA=$CRAFT_STAGE/etc
             mkdir -p $SNAP_COMMON
             mkdir -p $SNAP_DATA
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 /usr/lib/x86_64-linux-gnu/libnuma.so.1
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 /usr/lib/x86_64-linux-gnu/libaio.so.1
+            mkdir -p $CRAFT_STAGE/var/lib/mysql
             $CRAFT_STAGE/snap.charmed-mysql/hooks/install
     non-root-user:
         plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -29,25 +29,21 @@ parts:
             - charmed-mysql/8.0/edge
         override-stage: |
             craftctl default
-            mkdir -p $CRAFT_STAGE/var/lib/mysql
+            SNAP=$CRAFT_STAGE
+            SNAP_COMMON=$CRAFT_STAGE/var/snap/charmed-mysql/common
+            SNAP_DATA=$CRAFT_STAGE/var/snap/charmed-mysql/current
+            mkdir -p $SNAP_COMMON
+            mkdir -p $SNAP_DATA
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 /usr/lib/x86_64-linux-gnu/libnuma.so.1
             ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 /usr/lib/x86_64-linux-gnu/libaio.so.1
-            rm -rf /var/lib/mysql/
-            mysqld --initialize
-            cp -r /var/lib/mysql $CRAFT_STAGE/var/lib
-            chown 1000:1000 $CRAFT_STAGE/var/lib/mysql
-        override-prime: |
-            craftctl default
-            mv -f $CRAFT_PRIME/etc/mysql/mysql.cnf $CRAFT_PRIME/etc/mysql/my.cnf
-            mkdir -p $CRAFT_PRIME/var/log/mysql
-            chown -R 1000:1000 $CRAFT_PRIME/var/log/mysql
+            $CRAFT_STAGE/snap.charmed-mysql/hooks/install
     non-root-user:
         plugin: nil
         after: [charmed-mysql]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
-            groupadd -R $CRAFT_OVERLAY -g 1000 mysql
-            useradd -R $CRAFT_OVERLAY -M -r -g mysql -u 1000 mysql
+            groupadd -R $CRAFT_OVERLAY -g 584788 mysql
+            useradd -R $CRAFT_OVERLAY -M -r -g mysql -u 584788 mysql
         override-prime: |
             craftctl default
             # This is only needed until this bug is resolved with pebble
@@ -57,10 +53,10 @@ parts:
             for i in "${array[@]}"
             do
                 cp /etc/skel/"$i" $CRAFT_PRIME/home/mysql
-                chown 1000:1000 $CRAFT_PRIME/home/mysql/"$i"
+                chown 584788 $CRAFT_PRIME/home/mysql/"$i"
             done
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
-            chown -R 1000:1000 $CRAFT_PRIME/var/lib/mysql*
-            chown -R 1000:1000 $CRAFT_PRIME/var/run/mysqld
-            chown -R 1000:1000 $CRAFT_PRIME/etc/mysql
+            chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
+            chown -R 584788 $CRAFT_PRIME/var/run/mysqld
+            chown -R 584788 $CRAFT_PRIME/etc/mysql

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,9 +3,9 @@ base: ubuntu:22.04 # the base environment for this ROCK
 version: '8.0.31' # just for humans. Semantic versioning is recommended
 summary: Charmed MySQL ROCK OCI # 79 char long summary
 description: |
-    MySQL built from the official MySQL package 
-    from the MySQL repository and installs 
-    mysql-shell.  For more information on ROCKs, visit 
+    MySQL built from the official MySQL package
+    from the MySQL repository and installs
+    mysql-shell.  For more information on ROCKs, visit
     the https://github.com/canonical/rockcraft.
 license: Apache-2.0 # your application's SPDX license
 cmd:
@@ -30,8 +30,10 @@ parts:
         override-stage: |
             craftctl default
             mkdir -p $CRAFT_STAGE/var/lib/mysql
-            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 /usr/lib/x86_64-linux-gnu/libnuma.so.1
-            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 /usr/lib/x86_64-linux-gnu/libaio.so.1
+            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libnuma.so.1 \
+                /usr/lib/x86_64-linux-gnu/libnuma.so.1
+            ln -sf /root/parts/packages-deb/install/usr/lib/x86_64-linux-gnu/libaio.so.1 \
+                /usr/lib/x86_64-linux-gnu/libaio.so.1
             rm -rf /var/lib/mysql/
             mysqld --initialize
             cp -r /var/lib/mysql $CRAFT_STAGE/var/lib

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,37 +21,12 @@ platforms: # The platforms this ROCK should be built on and run on
     amd64:
 
 parts:
-    mysql-repo:
+    charmed-mysql:
         plugin: nil
-        override-pull: |
-            export DEBIAN_FRONTEND=noninteractive
-            export CONFIG_VERSION="0.8.22-1"
-            apt-get update
-            apt-get install -y wget lsb-release gnupg
-            wget -q https://dev.mysql.com/get/mysql-apt-config_${CONFIG_VERSION}_all.deb \
-                -O /tmp/mysql-apt-config_${CONFIG_VERSION}_all.deb
-            dpkg -i /tmp/mysql-apt-config_${CONFIG_VERSION}_all.deb
-            apt-get update
-    percona-repo:
-        plugin: nil
-        override-pull: |
-            export DEBIAN_FRONTEND=noninteractive
-            apt-get update
-            apt-get install -y wget lsb-release
-            wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-            dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-            apt-get update
-    packages-deb:
-        plugin: nil
-        after:
-            - mysql-repo
-            - percona-repo
         stage-packages:
-            - mysql-server
-            - mysql-router
-            - mysql-shell
-            - percona-xtrabackup-80
             - util-linux
+        stage-snaps:
+            - charmed-mysql/8.0/edge
         override-stage: |
             craftctl default
             mkdir -p $CRAFT_STAGE/var/lib/mysql
@@ -68,7 +43,7 @@ parts:
             chown -R 1000:1000 $CRAFT_PRIME/var/log/mysql
     non-root-user:
         plugin: nil
-        after: [packages-deb]
+        after: [charmed-mysql]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 1000 mysql

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,109 @@
+[tox]
+requires =
+	tox>=4
+env_list = lint, integration
+
+[testenv]
+setenv =
+	version=5.0
+	repo=https://github.com/canonical/mysql-k8s-operator.git
+	base-name=docker.io/dataplatformoci/charmed-mysql
+
+[testenv:lint]
+description = run linters
+skip_install = true
+deps =
+	yamllint
+commands = 
+	yamllint --no-warnings rockcraft.yaml .github
+
+[testenv:integration-charm]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-charm
+
+[testenv:integration-database-relation]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-database-relation
+
+[testenv:integration-osm-mysql]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-osm-mysql
+
+[testenv:integration-replication]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-replication
+
+[testenv:integration-self-healing]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-self-healing
+
+[testenv:integration-tls]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-tls
+
+[testenv:integration-backups]
+description = run operator integration tests
+skip_install = true
+allowlist_externals =
+	tox
+	microk8s
+	bash
+commands = 
+	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
+	tox --workdir operator -c operator -e integration-backups

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list = lint, integration
 
 [testenv]
 setenv =
-	version=5.0
+	version=8.0.31
 	repo=https://github.com/canonical/mysql-k8s-operator.git
 	base-name=docker.io/dataplatformoci/charmed-mysql
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-charm
 
@@ -38,8 +38,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-database-relation
 
@@ -51,8 +51,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-osm-mysql
 
@@ -64,8 +64,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-replication
 
@@ -77,8 +77,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-self-healing
 
@@ -90,8 +90,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-tls
 
@@ -103,7 +103,7 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqldb_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqldb_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-backups

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-charm
 
@@ -38,8 +38,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-database-relation
 
@@ -51,8 +51,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-osm-mysql
 
@@ -64,8 +64,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-replication
 
@@ -77,8 +77,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-self-healing
 
@@ -90,8 +90,8 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-tls
 
@@ -103,7 +103,7 @@ allowlist_externals =
 	microk8s
 	bash
 commands = 
-	bash -ec 'if ! [ -f charmed-mysqld_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
-	microk8s ctr image import charmed-mysqld_{env:version}_amd64.rock --base-name {env:base-name}
+	bash -ec 'if ! [ -f charmed-mysql_{env:version}_amd64.rock ]; then rockcraft pack; fi' {posargs}
+	microk8s ctr image import charmed-mysql_{env:version}_amd64.rock --base-name {env:base-name}
 	bash -ec 'if ! [ -d operator ]; then git clone {env:repo} operator; fi' {posargs}
 	tox --workdir operator -c operator -e integration-backups


### PR DESCRIPTION
## Issue
The rock is based on deb packages and lacks the mysqld-exporter at this time.

## Solution
The rock is converted to the updated snap with all the the required components including the bits for the observability stack.