### PR TITLE
Fix publishing branch filters

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,10 +2,10 @@ name: Publish ROCK
 on:
   push:
     branches:
-      - '*.*/stable'
+      - 8.0-22.04
   workflow_dispatch:
     branches:
-      - '*.*/stable'
+      - 8.0-22.04
 
 jobs:
   build:


### PR DESCRIPTION
## Issue
The previous PR mistakenly overwrote the branch filtering for an `on_push` event which prevented the updated Image from being published to docker hub.

## Solution
Update the filters for an `on_push` event to `8.0-22.04` as it is the only supported version at this time.