### PR TITLE
Add Foresight actions to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: 'Foresight: Collect workflow telemetry'
+        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup LXD

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,6 +23,8 @@ jobs:
           - integration-backups
       fail-fast: false
     steps:
+      - name: 'Foresight: Collect workflow telemetry'
+        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup operator environment

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Foresight: Collect workflow telemetry'
+        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install tox

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: 'Foresight: Collect workflow telemetry'
+        uses: runforesight/foresight-workflow-kit-action@v1
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Docker


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-operator/pull/161

Skipped collecting integration test results to avoid cluttering Foresight results for charm repos