### PR TITLE
Add missing package required by MySQL v8.0.32

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -34,6 +34,7 @@ parts:
             - libexpat1
             - python3
             - ca-certificates
+            - libedit2
         stage-snaps:
             - charmed-mysql/8.0/edge
         override-stage: |


### PR DESCRIPTION
## Issue
We are missing a package (`libedit2`) in the charmed-mysql ROCK that is required by MySQL 8.0.32

```
/usr/bin/mysql: error while loading shared libraries: libedit.so.2: cannot open shared object file: No such file or directory
```

## Solution
Install the package as part of the `overlay-packages`