### PR TITLE
Add missing dependency for mysql cli

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -56,6 +56,8 @@ parts:
                 /usr/lib/x86_64-linux-gnu/libprotobuf-lite.so.23
             ln -sf $LIB_DIR/libicudata.so.70 \
                 /usr/lib/x86_64-linux-gnu/libicudata.so.70
+            ln -sf $LIB_DIR/libedit.so.2 \
+                /usr/lib/x86_64-linux-gnu/libedit.so.2
             rm -rf /var/lib/mysql/
             mysqld --initialize
             cp -r /var/lib/mysql $CRAFT_STAGE/var/lib


### PR DESCRIPTION
## Issue

mysql cli is breaking in the rock due to missing lib


## Solution

Ensure the lib is carried over to the rock
