### PR TITLE
Remove cmd from rockcraft.yaml

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,12 +8,6 @@ description: |
     mysql-shell.  For more information on ROCKs, visit
     the https://github.com/canonical/rockcraft.
 license: Apache-2.0 # your application's SPDX license
-services:
-    mysqld_safe:
-        override: merge
-        command: /usr/sbin/mysqld_safe
-        user: mysql
-        group: mysql
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -11,7 +11,7 @@ license: Apache-2.0 # your application's SPDX license
 services:
     mysqld:
         override: merge
-        command: /usr/sbin/mysqld
+        command: /usr/sbin/mysqld_safe
         user: mysql
         group: mysql
 platforms: # The platforms this ROCK should be built on and run on

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,15 +8,12 @@ description: |
     mysql-shell.  For more information on ROCKs, visit
     the https://github.com/canonical/rockcraft.
 license: Apache-2.0 # your application's SPDX license
-cmd:
-    - /usr/bin/setpriv
-    - --clear-groups
-    - --reuid
-    - mysql
-    - --regid
-    - mysql
-    - --
-    - /usr/sbin/mysqld
+services:
+    mysqld:
+        override: merge
+        command: /usr/sbin/mysqld
+        user: mysql
+        group: mysql
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -9,7 +9,7 @@ description: |
     the https://github.com/canonical/rockcraft.
 license: Apache-2.0 # your application's SPDX license
 services:
-    mysqld:
+    mysqld_safe:
         override: merge
         command: /usr/sbin/mysqld_safe
         user: mysql


### PR DESCRIPTION
[dpe-1684](https://warthogs.atlassian.net/browse/DPE-1684)

## Issue
With the new release of rockcraft, the `cmd` section of the rockcraft.yaml file is deprecated. Instead, pebble is the default entrypoint, and `cmd` gets replaced with pebble `services`

## Solution
Remove the `cmd` section, and intentionally do not replace it with the `services` section. We do not add `mysqld` as a service as the ROCK will be used by mysql-router-k8s-operator as well