### PR TITLE
Create and chown log directory for mysqlrouter

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -86,6 +86,8 @@ parts:
             done
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
+            mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
             chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
             chown -R 584788 $CRAFT_PRIME/var/run/mysqld
             chown -R 584788 $CRAFT_PRIME/etc/mysql
+            chown -R 584788 $CRAFT_PRIME/var/log/mysqlrouter


### PR DESCRIPTION
[dpe-1684](https://warthogs.atlassian.net/browse/DPE-1684)

## Issue
MySQLRouter requires a log directory that the `mysql` user has permissions to write to (as the mysqlrouter process is run with `mysql` user)

## Solution
Create the directory in the rockcraft and chown it for the `mysql` user