### PR TITLE
Create `/etc/mysqlrouter` directory

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -77,8 +77,10 @@ parts:
             done
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
+            mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
             chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
             chown -R 584788 $CRAFT_PRIME/var/run/mysqld
             chown -R 584788 $CRAFT_PRIME/etc/mysql
+            chown -R 584788 $CRAFT_PRIME/etc/mysqlrouter
             chown -R 584788 $CRAFT_PRIME/var/log/mysqlrouter


### PR DESCRIPTION
## Issue
MySQL Router bootstrap fails because directory doesn't exist