### PR TITLE
[DPE-2080] Generate dpkg manifest

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -84,3 +84,20 @@ parts:
             chown -R 584788 $CRAFT_PRIME/etc/mysql
             chown -R 584788 $CRAFT_PRIME/etc/mysqlrouter
             chown -R 584788 $CRAFT_PRIME/var/log/mysqlrouter
+            # Generate dpkg.query
+            mkdir -p $CRAFT_PRIME/usr/share/rocks
+            echo "# os-release" > $CRAFT_PRIME/usr/share/rocks/dpkg.query
+            cat \
+            ${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/etc/os-release \
+            >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
+            echo "# dpkg-query" >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
+            declare -a fields
+            fields+=('${db:Status-Abbrev}')
+            fields+=('${binary:Package}')
+            fields+=('${Version}')
+            fields+=('${source:Package}')
+            fields+=('${Source:Version}')
+            printf -v dpkg_ops '%s,' "${fields[@]}"
+            dpkg-query -W -f "${dpkg_ops}\n" \
+            --root=${CRAFT_PROJECT_DIR}/../parts/charmed-mysql/layer/ \
+            >> $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
## Issue
Manifest of installed packages is necessary for security auditing

## Solution
Generate a manifest based on packages installed in the `charmed-mysql` part