### PR TITLE
Fix permissions for `/home/mysql` directory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
           sudo snap install yq
           sudo snap install --classic --channel edge rockcraft
       - name: Build ROCK
+        id: pack
         run: |
           app_version=$(yq '.version' rockcraft.yaml)
           version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
@@ -28,6 +29,13 @@ jobs:
           tag=${version}-${base}_edge
           sed -i "s/${app_version}/${tag}/g" rockcraft.yaml
           rockcraft pack
+      - name: Upload rockcraft logs
+        if: ${{ failure() && steps.pack.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: rockcraft-build-logs
+          path: ~/.local/state/rockcraft/log/
+          if-no-files-found: error
       - name: Upload locally built ROCK artifact
         uses: actions/upload-artifact@v3
         with:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -63,12 +63,9 @@ parts:
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 584788 mysql
-            useradd -R $CRAFT_OVERLAY -M -r -g mysql -u 584788 mysql
+            useradd -R $CRAFT_OVERLAY -r -g mysql -u 584788 mysql
         override-prime: |
             craftctl default
-            # This is only needed until this bug is resolved with pebble
-            # https://github.com/canonical/pebble/issues/189
-            mkdir -p $CRAFT_PRIME/home/mysql
             array=( .bash_logout .bashrc .profile )
             for i in "${array[@]}"
             do

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 584788 mysql
-            useradd -R $CRAFT_OVERLAY -m -r -g mysql -u 584788 mysql
+            useradd -R $CRAFT_OVERLAY --create-home -r -g mysql -u 584788 mysql
         override-prime: |
             craftctl default
             array=( .bash_logout .bashrc .profile )

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 584788 mysql
-            useradd -R $CRAFT_OVERLAY -r -g mysql -u 584788 mysql
+            useradd -R $CRAFT_OVERLAY -m -r -g mysql -u 584788 mysql
         override-prime: |
             craftctl default
             array=( .bash_logout .bashrc .profile )

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -70,14 +70,13 @@ parts:
             for i in "${array[@]}"
             do
                 cp /etc/skel/"$i" $CRAFT_PRIME/home/mysql
-                chown 584788 $CRAFT_PRIME/home/mysql/"$i"
             done
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
-            chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
-            chown -R 584788 $CRAFT_PRIME/var/run/mysqld
-            chown -R 584788 $CRAFT_PRIME/etc/mysql
-            chown -R 584788 $CRAFT_PRIME/etc/mysqlrouter
-            chown -R 584788 $CRAFT_PRIME/var/log/mysqlrouter
+            chown -R mysql $CRAFT_PRIME/var/lib/mysql*
+            chown -R mysql $CRAFT_PRIME/var/run/mysqld
+            chown -R mysql $CRAFT_PRIME/etc/mysql
+            chown -R mysql:mysql $CRAFT_PRIME/etc/mysqlrouter
+            chown -R mysql:mysql $CRAFT_PRIME/var/log/mysqlrouter

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -75,11 +75,11 @@ parts:
             mkdir -p $CRAFT_PRIME/var/run/mysqld
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
-            chown -R mysql $CRAFT_PRIME/var/lib/mysql*
-            chown -R mysql $CRAFT_PRIME/var/run/mysqld
-            chown -R mysql $CRAFT_PRIME/etc/mysql
-            chown -R mysql:mysql $CRAFT_PRIME/etc/mysqlrouter
-            chown -R mysql:mysql $CRAFT_PRIME/var/log/mysqlrouter
+            chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
+            chown -R 584788 $CRAFT_PRIME/var/run/mysqld
+            chown -R 584788 $CRAFT_PRIME/etc/mysql
+            chown -R 584788:584788 $CRAFT_PRIME/etc/mysqlrouter
+            chown -R 584788:584788 $CRAFT_PRIME/var/log/mysqlrouter
             # Generate dpkg.query
             mkdir -p $CRAFT_PRIME/usr/share/rocks
             echo "# os-release" > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
`/home/mysql` is owned by `root:root` but should be owned by `mysql:mysql`

Needed to run `mysqlsh` as non-root user