### PR TITLE
Add mysql-shell python dependencies

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,7 +27,6 @@ parts:
             - ca-certificates
             - libedit2
             # mysqlsh dependencies
-            # TODO: remove once added to mysql-shell PPA
             - python3-certifi
             - python3-yaml
         stage-snaps:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -26,6 +26,10 @@ parts:
             - python3
             - ca-certificates
             - libedit2
+            # mysqlsh dependencies
+            # TODO: remove once added to mysql-shell PPA
+            - python3-certifi
+            - python3-yaml
         stage-snaps:
             - charmed-mysql/8.0/edge
         override-stage: |


### PR DESCRIPTION
`certifi` and `yaml` were added to the mysql-shell PPA but are not present in the rock
