### PR TITLE
DPE-2424 Update rock version to 8.0.34

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql # the name of your ROCK
 base: ubuntu:22.04 # the base environment for this ROCK
-version: '8.0.33' # just for humans. Semantic versioning is recommended
+version: '8.0.34' # just for humans. Semantic versioning is recommended
 summary: Charmed MySQL ROCK OCI # 79 char long summary
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
## Issue
We updated the `charmed-mysql` snap (revision 69) in `8.0/edge` to be v8.0.34. Rebuilding the rock will tag the wrong versions

## Solution
Update version tag to 8.0.34