### PR TITLE
Add logrotate to the list of packages installed

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,6 +16,7 @@ parts:
         plugin: nil
         overlay-packages:
             - util-linux
+            - logrotate
             - libssh-4
             - libbrotli1
             - libicu70
@@ -60,6 +61,8 @@ parts:
             mv -f $CRAFT_PRIME/etc/mysql/mysql.cnf $CRAFT_PRIME/etc/mysql/my.cnf
             mkdir -p $CRAFT_PRIME/var/log/mysql
             chown -R 584788:584788 $CRAFT_PRIME/var/log/mysql
+        organize:
+            usr/share/doc/logrotate/copyright: licenses/COPYRIGHT-logrotate
     non-root-user:
         plugin: nil
         after:


### PR DESCRIPTION
## Issue
We need to install the logrotate package for the charm to be able to rotate mysql text logs

## Solution
Install the logrotate package, and organize its copyright file under licenses