### PR TITLE
Update rock version to 8.0.35

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,13 +22,7 @@ jobs:
           sudo snap install --classic --channel edge rockcraft
       - name: Build ROCK
         id: pack
-        run: |
-          app_version=$(yq '.version' rockcraft.yaml)
-          version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
-          base=$(yq '(.base|split(":"))[1]' rockcraft.yaml)
-          tag=${version}-${base}_edge
-          sed -i "s/${app_version}/${tag}/g" rockcraft.yaml
-          rockcraft pack
+        run: rockcraft pack
       - name: Upload rockcraft logs
         if: ${{ failure() && steps.pack.outcome == 'failure' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check_version.yaml
+++ b/.github/workflows/check_version.yaml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-      - name: 'Foresight: Collect workflow telemetry'
-        uses: runforesight/foresight-workflow-kit-action@v1
       - uses: actions/checkout@v3
       - name: Install yq
         run: sudo snap install yq

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           name: charmed-mysql-rock
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
@@ -42,9 +42,9 @@ jobs:
         run: |
           app=$(yq .name rockcraft.yaml)
           version=$(yq '(.version)' rockcraft.yaml)
-          base=$(yq '(.base|split(":"))[1]' rockcraft.yaml)
+          base=$(yq '(.base|split("@"))[1]' rockcraft.yaml)
           tag=${version}-${base}_edge
           sudo skopeo --insecure-policy copy \
-            oci-archive:${app}_${tag}_amd64.rock \
+            oci-archive:${app}_${version}_amd64.rock \
             docker-daemon:ghcr.io/canonical/${app}:${tag}
           docker push ghcr.io/canonical/${app}:${tag}

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -15,18 +15,17 @@ jobs:
       - name: Install Syft
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/4fc17edd146af34ab06f5b0443ef8ddac3aaf076/install.sh | sh -s -- -b /usr/local/bin
-      - name: Set tag
+      - name: Set version
         run: |
           version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
-          base=$(yq '(.base|split(":"))[1]' rockcraft.yaml)
-          echo "tag=${version}-${base}_edge" >> "$GITHUB_ENV"
+          echo "=${version}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v3
         with:
           name: charmed-mysql-rock
       - name: Create SBOM
-        run: syft charmed-mysql_${{env.tag}}_amd64.rock -o spdx-json=charmed-mysql_${{env.tag}}_amd64.rock.spdx.json
+        run: syft charmed-mysql_${{env.version}}_amd64.rock -o spdx-json=charmed-mysql_${{env.version}}_amd64.rock.spdx.json
       - name: Upload SBOM
         uses: actions/upload-artifact@v3
         with:
-          path: "charmed-mysql_${{env.tag}}_amd64.rock.spdx.json"
-          name: charmed-mysql_${{env.tag}}_amd64.rock.spdx.json
+          path: "charmed-mysql_${{env.version}}_amd64.rock.spdx.json"
+          name: charmed-mysql_${{env.version}}_amd64.rock.spdx.json

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,5 @@
 name: charmed-mysql # the name of your ROCK
-base: ubuntu:22.04 # the base environment for this ROCK
+base: ubuntu@22.04 # the base environment for this ROCK
 version: '8.0.34' # just for humans. Semantic versioning is recommended
 summary: Charmed MySQL ROCK OCI # 79 char long summary
 description: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql # the name of your ROCK
 base: ubuntu:22.04 # the base environment for this ROCK
-version: '8.0.34' # just for humans. Semantic versioning is recommended
+version: '8.0.35' # just for humans. Semantic versioning is recommended
 summary: Charmed MySQL ROCK OCI # 79 char long summary
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
## Issue

We updated the charmed-mysql snap (revision 91) in 8.0/edge to be v8.0.35. Rebuilding the rock will tag the wrong versions

## Solution

Update version tag to 8.0.35
