### PR TITLE
[DPE-4573] Update the mysql version as the 8.0/edge snap is now built with 8.0.39

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@22.04
-version: '8.0.37'
+version: '8.0.39'
 summary: Charmed MySQL ROCK OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
## Issue
We have updated `8.0/edge` in charmed-mysql-snap to `8.0.39`. However, images re-built on `8.0-22.04` branch will be tagged with `8.0.37` 

## Solution
Update version to `8.0.39`

## TODO
Check with image is the latest one tagged with `8.0.37` that is actually 8.0.37. Then retag and repush this image with the `8.0.37` tag on GHCR
