### PR TITLE
[DPE-5063] Update ROCK to MySQL v8.0.40

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,4 +48,4 @@ jobs:
 
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v17
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,13 +15,13 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v17
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.4
 
   release:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v17
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v29.0.4
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@22.04
-version: '8.0.39'
+version: '8.0.40'
 summary: Charmed MySQL rock OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
## Issue
The latest 8.0/edge snap is updated to MySQL v8.0.40

## Solution
Update the version of the rock which builds on top of the 8.0/edge snap