### PR TITLE
[MISC] Update README old name refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # MySQL Server rock
 [![Release to GHCR](https://github.com/canonical/charmed-mysql-rock/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/charmed-mysql-rock/actions/workflows/release.yaml)
 
-This repository contains the packaging metadata for creating a rock of MySQL built from the official ubuntu MySQL package from the Ubuntu repository and further installs mysql-shell.  For more information on rocks, visit the [rockcraft Github](https://github.com/canonical/rockcraft). 
+This repository contains the packaging metadata for creating a rock of MySQL built from
+the official ubuntu MySQL package from the Ubuntu repository and further installs mysql-shell.
+For more information on rocks, visit the [rockcraft Github](https://github.com/canonical/rockcraft). 
 
 Built for use in the [MySQL k8s charm](https://github.com/canonical/mysql-k8s-operator).
 
 ## Building the rock
-The steps outlined below are based on the assumption that you are building the rock with the latest LTS of Ubuntu.  If you are using another version of Ubuntu or another operating system, the process may be different.
+The steps outlined below are based on the assumption that you are building the rock with the latest LTS of Ubuntu.
+If you are using another version of Ubuntu or another operating system, the process may be different.
 
 ### Clone Repository
 ```bash
-git clone git@github.com:canonical/charmed-mysql-container.git
-cd charmed-mysql-container
+git clone git@github.com:canonical/charmed-mysql-rock.git
+cd charmed-mysql-rock
 ```
+
 ### Installing Prerequisites
 ```bash
 sudo snap install rockcraft --edge
@@ -20,12 +24,15 @@ sudo snap install docker
 sudo snap install lxd
 sudo snap install skopeo --edge --devmode
 ```
+
 ### Configuring Prerequisites
 ```bash
 sudo usermod -aG docker $USER 
 sudo lxd init --auto
 ```
+
 *_NOTE:_* You will need to open a new shell for the group change to take effect (i.e. `su - $USER`)
+
 ### Packing and Running the rock
 ```bash
 rockcraft pack
@@ -34,6 +41,5 @@ docker run --rm -it <username>/mysql-server:<tag>
 ```
 
 ## License
-The MySQL Server rock is free software, distributed under the Apache
-Software License, version 2.0. See
-[LICENSE](https://github.com/canonical/charmed-mysql-container/blob/8.0-22.04/licenses)
+The MySQL Server rock is free software, distributed under the Apache Software License, version 2.0.
+See [LICENSE](https://github.com/canonical/charmed-mysql-rock/blob/8.0-22.04/LICENSE)


### PR DESCRIPTION
This PR updates the README file by:

- Fixing all `charmed-mysql-container` references to use the new repository name.
- Splitting lines at ~100 characters width, to improve readability on non-wrapping editors.