### PR TITLE
[DPE-7083] Update mysql rock to 8.0.42

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@22.04
-version: '8.0.41'
+version: '8.0.42'
 summary: Charmed MySQL rock OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
This PR updates mysql rock to version 8.0.42.

The rockcraft YAML file targets charmed-mysql snap in channel `8.0/edge`, which has been already been updated when merging [this PR](https://github.com/canonical/charmed-mysql-snap/pull/69) (see associated [CI run](https://github.com/canonical/charmed-mysql-snap/actions/runs/15211518990)).
