### PR TITLE
[DPE-8301] Update mysql to 8.0.43

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@22.04
-version: '8.0.42'
+version: '8.0.43'
 summary: Charmed MySQL rock OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
This PR updates charmed mysql rock to version 8.0.43.

The rockcraft YAML file targets charmed-mysql snap in channel `8.0/edge`, which needs to be updated by [this PR](https://github.com/canonical/charmed-mysql-snap/pull/75).