### PR TITLE
[MISC] Install MySQL 8.4 binary dependencies

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -22,6 +22,7 @@ parts:
             - libssh-4
             - libbrotli1
             - libexpat1
+            - libtirpc3t64
             - python3
             - ca-certificates
             - libedit2


### PR DESCRIPTION
This PR adds missing Ubuntu 24.04 binary dependencies to the rock, only visible when installing plugins.

These packages were present in the Ubuntu 22.04 rocks (i.e. MySQL 8.0) as they were part of the popular `glibc` package. However, that is not the case anymore.
