### PR TITLE
[DPE-9477] Update mysql rock to 8.0.45

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           APP="$(yq .name rockcraft.yaml)"
           ROCK_VERSION="$(yq .version rockcraft.yaml)"
           CHANNEL="$(yq '.parts.charmed-mysql.stage-snaps[0]' rockcraft.yaml | cut -c15-)"
-          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}" | awk -F ' ' '{print $2}')"
+          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}:" | awk -F ' ' '{print $2}')"
           if [ "${ROCK_VERSION}" != "${SNAP_VERSION}" ]; then
               echo "VERSION MISMATCH DETECTED"
               echo "Rock version: ${ROCK_VERSION}"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@22.04
-version: '8.0.44'
+version: '8.0.45'
 summary: Charmed MySQL rock OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
This PR updates mysql rock to version 8.0.45

The rockcraft YAML file targets charmed-mysql snap in channel `8.0/edge`, which has been already been updated when merging https://github.com/canonical/charmed-mysql-snap/pull/87 (see associated [CI run](https://github.com/canonical/charmed-mysql-snap/actions/runs/22341679611)).
