### PR TITLE
[MISC] fixed repository scan reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.1
 
   check-version:
     name: Check version
@@ -38,4 +38,4 @@ jobs:
 
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,13 +15,13 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1
 
   release:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v42.0.1
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,18 +9,19 @@ on:
 
 permissions:
   contents: read  # Set the GITHUB_TOKEN permissions to read-only
+  security-events: write  # Required for uploading Trivy SARIF results
 
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1
   scan:
-    name: Trivy scan and SBOM Generation
+    name: Trivy scan
     needs: build
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install required dependencies
         run: |
           # rockcraft
@@ -29,7 +30,7 @@ jobs:
           # yq
           sudo snap install yq
       - name: Download rock package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -38,38 +39,16 @@ jobs:
           full_version="$(yq .version rockcraft.yaml)"
           sudo rockcraft.skopeo --insecure-policy copy \
               "oci-archive:charmed-mysql_${full_version}_amd64.rock" \
-              "docker-daemon:trivy/charmed-mysql:test"
+              "docker-daemon:trivy/mysql:test"
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.34.2
         with:
-          image-ref: "trivy/charmed-mysql:test"
+          image-ref: "trivy/mysql:test"
           format: "sarif"
           output: "trivy-results.sarif"
-          severity: "MEDIUM,HIGH,CRITICAL"
+          severity: "HIGH,CRITICAL"
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-results.sarif"
-  sbom:
-    name: Trivy SBOM and Dependency Upload
-    needs: scan
-    if: github.event_name == 'push'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Run Trivy in GitHub SBOM mode and submit to Dependency Graph
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "image"
-          format: "spdx-json"
-          output: "dependency-results.sbom.json"
-          image-ref: "trivy/charmed-mysql:test"
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
-          severity: "MEDIUM,HIGH,CRITICAL"
-          scanners: "vuln"
-      - name: Upload trivy report as a Github artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-sbom-report
-          path: "${{ github.workspace }}/dependency-results.sbom.json"
-          retention-days: 90

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -39,11 +39,11 @@ jobs:
           full_version="$(yq .version rockcraft.yaml)"
           sudo rockcraft.skopeo --insecure-policy copy \
               "oci-archive:charmed-mysql_${full_version}_amd64.rock" \
-              "docker-daemon:trivy/mysql:test"
+              "docker-daemon:trivy/charmed-mysql:test"
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.34.2
         with:
-          image-ref: "trivy/mysql:test"
+          image-ref: "trivy/charmed-mysql:test"
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "HIGH,CRITICAL"


### PR DESCRIPTION

This pull request updates the Trivy security scan workflow to use newer actions, improves permissions, and simplifies the workflow by removing the SBOM generation job. The changes modernize dependencies, focus vulnerability scanning on higher-severity issues, and streamline artifact handling.

**Workflow and Dependency Updates:**

- Upgraded GitHub Actions dependencies to newer versions for improved stability and features, including `build_rock.yaml` (from `v32.2.0` to `v42.0.1`), `actions/checkout` (from `v4` to `v6`), `actions/download-artifact` (from `v4` to `v8`), `aquasecurity/trivy-action` (from `master` to `0.34.2`), and `github/codeql-action/upload-sarif` (from `v3` to `v4`). [[1]](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996R12-R24) [[2]](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996L32-R33) [[3]](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996L41-L75)

**Security and Scan Configuration:**

- Added `security-events: write` permission to allow uploading Trivy SARIF results to the GitHub Security tab.
- Changed Trivy scan to only report `HIGH` and `CRITICAL` severity vulnerabilities (previously included `MEDIUM`).


**Workflow Simplification:**

- Removed the separate SBOM and dependency upload job, focusing the workflow solely on vulnerability scanning and reporting. 