### PR TITLE
[DPE-9612] 8.0 - Tweak log-rotate dir permissions

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -56,9 +56,9 @@ parts:
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/lib/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
-            chown -R 584788 $CRAFT_PRIME/var/lib/mysql*
-            chown -R 584788 $CRAFT_PRIME/var/run/mysqld
-            chown -R 584788 $CRAFT_PRIME/etc/mysql
+            chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysql*
+            chown -R 584788:584788 $CRAFT_PRIME/var/run/mysqld
+            chown -R 584788:584788 $CRAFT_PRIME/etc/mysql
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/log/mysqlrouter

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -56,8 +56,10 @@ parts:
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/lib/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
+            chown -R 584788:584788 $CRAFT_PRIME/var/lib/logrotate
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysql*
             chown -R 584788:584788 $CRAFT_PRIME/var/run/mysqld
+            chown -R 584788:584788 $CRAFT_PRIME/etc/logrotate.d
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysql
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysqlrouter

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -51,6 +51,7 @@ parts:
             do
                 cp /etc/skel/"$i" $CRAFT_PRIME/home/mysql
             done
+            mkdir -p $CRAFT_PRIME/var/lib/mysql
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter


### PR DESCRIPTION
This PR makes all Logrotate files to be owned by the `mysql` user.

---

### Depends

- https://github.com/canonical/charmed-mysql-rock/pull/72

### Unblocks

- https://github.com/canonical/mysql-operators/pull/169