### PR TITLE
[MISC] 8.0 - Fix rock building

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,7 +17,6 @@ parts:
     charmed-mysql:
         plugin: nil
         overlay-packages:
-            - logrotate
             - libbrotli1
             - libedit2
             - libssh-4
@@ -26,6 +25,8 @@ parts:
             # mysqlsh dependencies
             - python3-certifi
             - python3-yaml
+        stage-packages:
+            - logrotate
         stage-snaps:
             - charmed-mysql/8.0/edge
         override-prime: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,14 +17,12 @@ parts:
     charmed-mysql:
         plugin: nil
         overlay-packages:
-            - util-linux
             - logrotate
             - libssh-4
             - libbrotli1
             - libicu70
             - libevent-core-2.1-7
             - libevent-pthreads-2.1-7
-            - libprotobuf-lite23
             - libexpat1
             - python3
             - ca-certificates

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,15 +18,11 @@ parts:
         plugin: nil
         overlay-packages:
             - logrotate
-            - libssh-4
             - libbrotli1
-            - libicu70
-            - libevent-core-2.1-7
-            - libevent-pthreads-2.1-7
-            - libexpat1
+            - libedit2
+            - libssh-4
             - python3
             - ca-certificates
-            - libedit2
             # mysqlsh dependencies
             - python3-certifi
             - python3-yaml


### PR DESCRIPTION
This PR fixed rock building of the charmed MySQL 8.0 rock, in order to unlock further development.

Seems like something changed, either in the `rockcraft` or in the `core22` snaps since the last time we built the rock, so that now package collisions in the first defined part crash the build process. I did a full audit of what is needed and by who, running the following commands:

```shell
# Within my local shell
sudo rockcraft pack
sudo rockcraft.skopeo --insecure-policy copy oci-archive:charmed-mysql_8.0.45_amd64.rock docker-daemon:sinclert/charmed-mysql:8.0-test
sudo docker run --rm -it sinclert/charmed-mysql:8.0-test &
sudo docker exec -it <container ID> bash

# Within the container shell
$ which logrotate
> ...
$ ldd /usr/bin/mysql
> ...
$ ldd /usr/bin/mysqlsh
> ...
$ ldd /usr/bin/mysqlrouter
> ...
$ ldd /usr/sbin/mysqld
> ...
```

### Review process:

- [Required] https://github.com/canonical/charmed-mysql-rock/pull/72/commits/9b9e85f6065552166a91092130be5e1f45a5bf66, unless committed the build process crashes.
- [Optional] https://github.com/canonical/charmed-mysql-rock/pull/72/commits/6b31c603f21684282f8b736800174e153e4e52dc, cleanup of packages listed as dependencies in `mysql-server-core-8.0` [metadata](https://packages.ubuntu.com/jammy/mysql-server-core-8.0).
- [Required] https://github.com/canonical/charmed-mysql-rock/pull/72/commits/e59ef32c9344643e77af63862c5db06d9a33dae2, unless committed the build process crashes.
