### PR TITLE
[MISC] 8.4 - Fix rock building

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,9 +17,7 @@ parts:
     charmed-mysql:
         plugin: nil
         overlay-packages:
-            - util-linux
             - logrotate
-            - libssh-4
             - libbrotli1
             - libexpat1
             - libtirpc3t64

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,11 +19,10 @@ parts:
         overlay-packages:
             - logrotate
             - libbrotli1
-            - libexpat1
+            - libedit2
             - libtirpc3t64
             - python3
             - ca-certificates
-            - libedit2
             # mysqlsh dependencies
             - python3-certifi
             - python3-yaml

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,7 +17,6 @@ parts:
     charmed-mysql:
         plugin: nil
         overlay-packages:
-            - logrotate
             - libbrotli1
             - libedit2
             - libtirpc3t64
@@ -26,6 +25,8 @@ parts:
             # mysqlsh dependencies
             - python3-certifi
             - python3-yaml
+        stage-packages:
+            - logrotate
         stage-snaps:
             - charmed-mysql/8.4/edge
         override-prime: |


### PR DESCRIPTION
This PR fixed rock building of the charmed MySQL 8.4 rock, in order to unlock further development.

Seems like something changed, either in the `rockcraft` or in the `core24` snaps since the last time we built the rock, so that now package collisions in the first defined part crash the build process. I did a full audit of what is needed and by who, running the following commands:

```shell
# Within my local shell
sudo rockcraft pack
sudo rockcraft.skopeo --insecure-policy copy oci-archive:charmed-mysql_8.4.8_amd64.rock docker-daemon:sinclert/charmed-mysql:8.4-test
sudo docker run --rm -it sinclert/charmed-mysql:8.4-test &
sudo docker exec -it <container ID> bash

# Within the container shell
$ which logrotate
> ...
$ ldd /usr/bin/mysql
> ...
$ ldd /usr/bin/mysqlsh
> ...
$ ldd /usr/bin/mysqlrouter
> ...
$ ldd /usr/sbin/mysqld
> ...
```

### Review process:

- [Required] https://github.com/canonical/charmed-mysql-rock/pull/73/commits/c566ede127e810229029ab332a90c907f14ed0cd, unless committed the build process crashes.
- [Optional] https://github.com/canonical/charmed-mysql-rock/pull/73/commits/750ee653bb259843b188ca7e7deaeec54178b719, cleanup of packages not required for the `mysqld` 8.4 binary to be fully linked.
- [Required] https://github.com/canonical/charmed-mysql-rock/pull/73/commits/6f61c2b03a254ff06c9eaee36b46b5b25fa2764e, unless committed the build process crashes.
