### PR TITLE
[DPE-9612] 8.0 - Create promtail directories

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -55,6 +55,8 @@ parts:
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
             mkdir -p $CRAFT_PRIME/var/run/mysqld
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
+            mkdir -p $CRAFT_PRIME/etc/promtail
+            mkdir -p $CRAFT_PRIME/opt/promtail
             mkdir -p $CRAFT_PRIME/var/lib/mysqlrouter
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/logrotate
@@ -63,6 +65,8 @@ parts:
             chown -R 584788:584788 $CRAFT_PRIME/etc/logrotate.d
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysql
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysqlrouter
+            chown -R 584788:584788 $CRAFT_PRIME/etc/promtail
+            chown -R 584788:584788 $CRAFT_PRIME/opt/promtail
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/log/mysqlrouter
             # Generate dpkg.query


### PR DESCRIPTION
This PR creates + grant ownership to the `promtail` process related directories, in order for the MySQL charms to integrate with the Grafana Agent charm (see [required directories](https://github.com/canonical/mysql-operators/blob/6e0e91e29a0dcf691a5914213c78e740a410fb8e/kubernetes/lib/charms/loki_k8s/v0/loki_push_api.py#L516-L517)).

---

Fixes COS Bundle integration test failures in the `8.0/edge` branch.
