### PR TITLE
[MISC] Create rolling-ops v1 folder - revert

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -53,7 +53,6 @@ parts:
             done
             mkdir -p $CRAFT_PRIME/var/lib/mysql
             mkdir -p $CRAFT_PRIME/var/lib/mysql-files
-            mkdir -p $CRAFT_PRIME/var/lib/rollingops
             mkdir -p $CRAFT_PRIME/var/run/mysqld
             mkdir -p $CRAFT_PRIME/etc/mysqlrouter
             mkdir -p $CRAFT_PRIME/etc/promtail
@@ -62,7 +61,6 @@ parts:
             mkdir -p $CRAFT_PRIME/var/log/mysqlrouter
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/mysql*
             chown -R 584788:584788 $CRAFT_PRIME/var/lib/logrotate
-            chown -R 584788:584788 $CRAFT_PRIME/var/lib/rollingops
             chown -R 584788:584788 $CRAFT_PRIME/var/run/mysqld
             chown -R 584788:584788 $CRAFT_PRIME/etc/logrotate.d
             chown -R 584788:584788 $CRAFT_PRIME/etc/mysql


### PR DESCRIPTION
This PR reverts PR https://github.com/canonical/charmed-mysql-rock/pull/83, once I clarified with Patricia that the new rolling-ops Python package only supports **charm** VM / container placed logs. We did not need to create + assign a new folder for it, just passing a base-directory with enough permissions 🤦🏻‍♂️ 
