### PR TITLE
[DPE-9970] 8.4 - Bump base to 26.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,6 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v48.1.1
-    with:
-      rockcraft-snap-channel: latest/edge
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,34 +16,37 @@ jobs:
     permissions:
       contents: read
 
-  check-version:
-    name: Check version
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions: {}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Install yq
-        run: sudo snap install yq
-      - name: Compare versions
-        run: |
-          APP="$(yq .name rockcraft.yaml)"
-          ROCK_VERSION="$(yq .version rockcraft.yaml)"
-          CHANNEL="$(yq '.parts.charmed-mysql.stage-snaps[0]' rockcraft.yaml | cut -c15-)"
-          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}:" | awk -F ' ' '{print $2}')"
-          if [ "${ROCK_VERSION}" != "${SNAP_VERSION}" ]; then
-              echo "VERSION MISMATCH DETECTED"
-              echo "Rock version: ${ROCK_VERSION}"
-              echo "SNAP version: ${SNAP_VERSION}"
-              exit 1
-          fi
+#  TODO: Uncomment when GitHub offers 26.04 runners
+#  check-version:
+#    name: Check version
+#    runs-on: ubuntu-26.04
+#    timeout-minutes: 15
+#    permissions: {}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v6
+#        with:
+#          persist-credentials: false
+#      - name: Install yq
+#        run: sudo snap install yq
+#      - name: Compare versions
+#        run: |
+#          APP="$(yq .name rockcraft.yaml)"
+#          ROCK_VERSION="$(yq .version rockcraft.yaml)"
+#          CHANNEL="$(yq '.parts.charmed-mysql.stage-snaps[0]' rockcraft.yaml | cut -c15-)"
+#          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}:" | awk -F ' ' '{print $2}')"
+#          if [ "${ROCK_VERSION}" != "${SNAP_VERSION}" ]; then
+#              echo "VERSION MISMATCH DETECTED"
+#              echo "Rock version: ${ROCK_VERSION}"
+#              echo "SNAP version: ${SNAP_VERSION}"
+#              exit 1
+#          fi
 
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v48.1.1
+    with:
+      rockcraft-snap-channel: latest/edge
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,6 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v48.1.1
-    with:
-      rockcraft-snap-channel: latest/edge
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v48.1.1
+    with:
+      rockcraft-snap-channel: latest/edge
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   scan:
     name: Trivy scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       security-events: write  # Required for uploading Trivy SARIF results
     steps:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,15 +16,6 @@ platforms:
 parts:
     charmed-mysql:
         plugin: nil
-        overlay-packages:
-            - libbrotli1
-            - libedit2
-            - libtirpc3t64
-            - python3
-            - ca-certificates
-            # mysqlsh dependencies
-            - python3-certifi
-            - python3-yaml
         stage-packages:
             - logrotate
         stage-snaps:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,5 @@
 name: charmed-mysql
-base: ubuntu@24.04
+base: ubuntu@26.04
 version: '8.4.8'
 summary: Charmed MySQL rock OCI
 description: |
@@ -73,7 +73,7 @@ parts:
             mkdir -p $CRAFT_PRIME/usr/share/rocks
             echo "# os-release" > $CRAFT_PRIME/usr/share/rocks/dpkg.query
             cat \
-            ${CRAFT_PROJECT_DIR}/../bundles/ubuntu-24.04/rootfs/etc/os-release \
+            ${CRAFT_PROJECT_DIR}/../bundles/ubuntu-26.04/rootfs/etc/os-release \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
             echo "# dpkg-query" >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
             declare -a fields


### PR DESCRIPTION
This PR makes the necessary changes to start building the rock for Ubuntu 26.04 So far, only Rockcraft 1.19.0 supports such base (see [release notes](https://github.com/canonical/rockcraft/releases/tag/1.19.0)), and it is only available on the `latest/edge` channel.
