### PR TITLE
[DPE-9970] 8.4 - Add 26.04 base missing libs

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,6 +16,15 @@ platforms:
 parts:
     charmed-mysql:
         plugin: nil
+        overlay-packages:
+            # mysql-client dependencies
+            - libedit2
+            # mysql-shell dependencies
+            - libbrotli1
+            - libgnutls30t64
+            - libgssapi-krb5-2
+            - python3-certifi
+            - python3-yaml
         stage-packages:
             - logrotate
         stage-snaps:


### PR DESCRIPTION
This PR fixes the linking process of MySQL binaries in the new Ubuntu 26.04 base rock, by installing the minimum set of dependencies that fulfill binaries LDD links. These dependencies were removed by mistaken due to a cached rock. In the future, we should **always** run:

```shell
rockcraft clean
rockcraft pack
```

---

Fixes PR https://github.com/canonical/charmed-mysql-rock/pull/86