### PR TITLE
[DPE-9970] 8.4 - Add 26.04 base missing libs (II)

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -22,7 +22,7 @@ parts:
             # mysql-shell dependencies
             - libbrotli1
             - libgnutls30t64
-            - libgssapi-krb5-2
+            - libtirpc3t64
             - python3-certifi
             - python3-yaml
         stage-packages:


### PR DESCRIPTION
This PR generalizes the installation of specific dynamically linked libraries, to also cover the MySQL plugins.

Fixes PRs https://github.com/canonical/charmed-mysql-rock/pull/86 + https://github.com/canonical/charmed-mysql-rock/pull/88