### PR TITLE
[DPE-9970] 8.4 - Enable 26.04 version check

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
           persist-credentials: false
       - name: Install yq
         run: sudo snap install yq
+      - name: Update package metadata
+        run: sudo apt update
       - name: Compare versions
         run: |
           APP="$(yq .name rockcraft.yaml)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,31 +16,30 @@ jobs:
     permissions:
       contents: read
 
-#  TODO: Uncomment when GitHub offers 26.04 runners
-#  check-version:
-#    name: Check version
-#    runs-on: ubuntu-26.04
-#    timeout-minutes: 15
-#    permissions: {}
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v6
-#        with:
-#          persist-credentials: false
-#      - name: Install yq
-#        run: sudo snap install yq
-#      - name: Compare versions
-#        run: |
-#          APP="$(yq .name rockcraft.yaml)"
-#          ROCK_VERSION="$(yq .version rockcraft.yaml)"
-#          CHANNEL="$(yq '.parts.charmed-mysql.stage-snaps[0]' rockcraft.yaml | cut -c15-)"
-#          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}:" | awk -F ' ' '{print $2}')"
-#          if [ "${ROCK_VERSION}" != "${SNAP_VERSION}" ]; then
-#              echo "VERSION MISMATCH DETECTED"
-#              echo "Rock version: ${ROCK_VERSION}"
-#              echo "SNAP version: ${SNAP_VERSION}"
-#              exit 1
-#          fi
+  check-version:
+    name: Check version
+    runs-on: ubuntu-26.04
+    timeout-minutes: 15
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Compare versions
+        run: |
+          APP="$(yq .name rockcraft.yaml)"
+          ROCK_VERSION="$(yq .version rockcraft.yaml)"
+          CHANNEL="$(yq '.parts.charmed-mysql.stage-snaps[0]' rockcraft.yaml | cut -c15-)"
+          SNAP_VERSION="$(snap info "${APP}" | grep "${CHANNEL}:" | awk -F ' ' '{print $2}')"
+          if [ "${ROCK_VERSION}" != "${SNAP_VERSION}" ]; then
+              echo "VERSION MISMATCH DETECTED"
+              echo "Rock version: ${ROCK_VERSION}"
+              echo "SNAP version: ${SNAP_VERSION}"
+              exit 1
+          fi
 
   build:
     name: Build rock

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,10 +23,10 @@ parts:
             - libbrotli1
             - libgnutls30t64
             - libtirpc3t64
-            - python3-certifi
-            - python3-yaml
         stage-packages:
             - logrotate
+            - python3-certifi
+            - python3-yaml
         stage-snaps:
             - charmed-mysql/8.4/edge
         override-prime: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: ubuntu@26.04
-version: '8.4.8'
+version: '8.4.10'
 summary: Charmed MySQL rock OCI
 description: |
     MySQL built from the official MySQL package


### PR DESCRIPTION
This PR enables back the Ubuntu 26.04 MySQL binaries version check (disabled given the lack of GH runners).

### Additional changes
- Bumped MySQL binaries to `8.4.10` by consuming the latest charmed-mysql snap.